### PR TITLE
Changed title of index page

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -19,7 +19,7 @@ MathJax = {
   src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-svg.js">
 </script>
     <link rel="stylesheet" href={{ "/assets/css/styles.css" | relative_url }}>
-    <title>{{ page.title }}</title>
+    <title>{% if page.name == "index.md" %}Into the shadow garten{% else %}{{ page.title }}{% endif %}</title>
 </head>
 <body>
     <div class="page-header">


### PR DESCRIPTION
This should fix the problem where the title of the page (in the tab menu) has HTML tags in it.`